### PR TITLE
Passwords: check and create hashes, modify passwords

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,7 @@
+include.path=${php.global.include.path}
+php.version=PHP_81
+source.encoding=UTF-8
+src.dir=src
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>ltb-project/ldap</name>
+        </data>
+    </configuration>
+</project>

--- a/src/Ltb/Ldap.php
+++ b/src/Ltb/Ldap.php
@@ -136,7 +136,147 @@ final class Ldap {
 
         return array($ldap_result,$errno,$entries);
     }
+    
+    /**
+     * Gets the value of the password attribute
+     * @param \LDAP\Connection|array $ldap An LDAP\Connection instance, returned by ldap_connect()
+     * @param string $dn the dn of the user
+     * @param type $pwdattribute the Attriubte that contains the password
+     * @return string the value of $pwdattribute
+     */
+    static function get_hashed_password($ldap, $dn, $pwdattribute): string {
+        $search_userpassword = ldap_read($ldap, $dn, "(objectClass=*)", array($pwdattribute));
+        if ($search_userpassword) {
+            return ldap_get_values($ldap, ldap_first_entry($ldap, $search_userpassword), $pwdattribute);
+        }
+    }
+    
+    /**
+     * Changes the password of an user while binded as the user in an Active Directory
+     * @param \LDAP\Connection|array $ldap An LDAP\Connection instance, returned by ldap_connect()
+     * @param string $dn the dn of the user
+     * @param string $oldpassword the old password
+     * @param string $password the new password
+     * @return array [$error_code, $error_msg]
+     */
+    static function change_ad_password_as_user($ldap, $dn, $oldpassword, $password): array {
+        # The AD password change procedure is modifying the attribute unicodePwd by
+        # first deleting unicodePwd with the old password and them adding it with the
+        # the new password
+        $oldpassword_hashed = make_ad_password($oldpassword);
 
+        $modifications = array(
+            array(
+                "attrib" => "unicodePwd",
+                "modtype" => LDAP_MODIFY_BATCH_REMOVE,
+                "values" => array($oldpassword_hashed),
+            ),
+            array(
+                "attrib" => "unicodePwd",
+                "modtype" => LDAP_MODIFY_BATCH_ADD,
+                "values" => array($password),
+            ),
+        );
+
+        ldap_modify_batch($ldap, $dn, $modifications);
+        $error_code = ldap_errno($ldap);
+        $error_msg = ldap_error($ldap);
+        return array($error_code, $error_msg);
+    }
+    
+    /**
+     * Changes the Password using extended password modification
+     * @param \LDAP\Connection|array $ldap An LDAP\Connection instance, returned by ldap_connect()
+     * @param string $dn the dn of the user
+     * @param string $oldpassword the old password
+     * @param string $password the new password
+     * @param array $userdata
+     * @param bool $use_ppolicy_control
+     * @return array [$error_code, $error_msg, $ppolicy_error_code]
+     */
+    static function change_password_with_exop($ldap, $dn, $oldpassword, $password, $userdata, $use_ppolicy_control): array {
+        $ppolicy_error_code = "";
+        $exop_passwd = FALSE;
+        if ( $use_ppolicy_control ) {
+            $ctrls = array();
+            $exop_passwd = ldap_exop_passwd($ldap, $dn, $oldpassword, $password, $ctrls);
+            $error_code = ldap_errno($ldap);
+            $error_msg = ldap_error($ldap);
+            if (!$exop_passwd) {
+                if (isset($ctrls[LDAP_CONTROL_PASSWORDPOLICYRESPONSE])) {
+                    $value = $ctrls[LDAP_CONTROL_PASSWORDPOLICYRESPONSE]['value'];
+                    if (isset($value['error'])) {
+                        $ppolicy_error_code = $value['error'];
+                        error_log("LDAP - Ppolicy error code: $ppolicy_error_code");
+                    }
+                }
+            }
+        } else {
+            $exop_passwd = ldap_exop_passwd($ldap, $dn, $oldpassword, $password);
+            $error_code = ldap_errno($ldap);
+            $error_msg = ldap_error($ldap);
+        }
+        if ($exop_passwd === TRUE) {
+            # If password change works update other data
+            if (!empty($userdata)) {
+                ldap_mod_replace($ldap, $dn, $userdata);
+                $error_code = ldap_errno($ldap);
+                $error_msg = ldap_error($ldap);
+            }
+        }
+        return array($error_code, $error_msg, $ppolicy_error_code);
+    }
+    
+    /**
+     * Changes Password using Password Policy Control
+     * @param \LDAP\Connection|array $ldap An LDAP\Connection instance, returned by ldap_connect()
+     * @param string $dn the dn of the user
+     * @param array $userdata the array, containing the new (hashed) password
+     * @return type
+     */
+    static function change_password_using_ppolicy($ldap, $dn, $userdata): array {
+        $error_code = "";
+        $error_msg = "";
+        $ctrls = array();
+        $ppolicy_error_code = "";
+        $ppolicy_replace = ldap_mod_replace_ext($ldap, $dn, $userdata, [['oid' => LDAP_CONTROL_PASSWORDPOLICYREQUEST]]);
+        if (ldap_parse_result($ldap, $ppolicy_replace, $error_code, $matcheddn, $error_msg, $referrals, $ctrls)) {
+            if (isset($ctrls[LDAP_CONTROL_PASSWORDPOLICYRESPONSE])) {
+                $value = $ctrls[LDAP_CONTROL_PASSWORDPOLICYRESPONSE]['value'];
+                if (isset($value['error'])) {
+                    $ppolicy_error_code = $value['error'];
+                    error_log("LDAP - Ppolicy error code: $ppolicy_error_code");
+                }
+            }
+        }
+        return array($error_code, $error_msg, $ppolicy_error_code);
+    }
+    
+    /**
+     * Changes Password
+     * @param \LDAP\Connection|array $ldap An LDAP\Connection instance, returned by ldap_connect()
+     * @param string $dn the dn of the user
+     * @param array $userdata the array, containing the new (hashed) password
+     * @return type
+     */
+    static function change_password($ldap, $dn, $userdata): array {
+        ldap_mod_replace($ldap, $dn, $userdata);
+        $error_code = ldap_errno($ldap);
+        $error_msg = ldap_error($ldap);
+        return array($error_code, $error_msg);
+    }
+
+    const PPOLICY_ERROR_CODE_TO_RESULT_MAPPER = [
+            0 => "passwordExpired",
+            1 => "accountLocked",
+            2 => "changeAfterReset",
+            3 => "passwordModNotAllowed",
+            4 => "mustSupplyOldPassword",
+            5 => "badquality",
+            6 => "tooshort",
+            7 => "tooyoung",
+            8 => "inhistory"
+        ];
 
 }
 ?>

--- a/src/Ltb/Password.php
+++ b/src/Ltb/Password.php
@@ -1,0 +1,312 @@
+<?php namespace Ltb;
+
+/**
+ * 
+ */
+final class Password {
+    # Create SSHA password
+    static function make_ssha_password($password): string {
+        $salt = random_bytes(4);
+        return "{SSHA}" . base64_encode(pack("H*", sha1($password . $salt)) . $salt);
+    }
+    
+    static function check_ssha_password($password, $hash): bool {
+        $salt = substr(base64_decode(substr($hash, 6)), 20);
+        $hash2 = "{SSHA}" . base64_encode(pack("H*", sha1($password . $salt)) . $salt);
+        return ($hash === $hash2);
+    }
+
+    # Create SSHA256 password
+    static function make_ssha256_password($password): string {
+        $salt = random_bytes(4);
+        return "{SSHA256}" . base64_encode(pack("H*", hash('sha256', $password . $salt)) . $salt);
+    }
+    
+    static function check_ssha256_password($password, $hash): bool {
+        $salt = substr(base64_decode(substr($hash, 9)), 32);
+        $hash2 = "{SSHA256}".base64_encode(hash('sha256', $password.$salt, true).$salt);
+        return ($hash === $hash2);
+    }
+
+    # Create SSHA384 password
+    static function make_ssha384_password($password): string {
+        $salt = random_bytes(4);
+        return "{SSHA384}" . base64_encode(pack("H*", hash('sha384', $password . $salt)) . $salt);
+    }
+    
+    static function check_ssha384_password($password, $hash): bool {
+        $salt = substr(base64_decode(substr($hash, 9)), 48);
+        $hash2 = "{SSHA384}".base64_encode(hash('sha384', $password.$salt, true).$salt);
+        return ($hash === $hash2);
+    }
+
+    # Create SSHA512 password
+    static function make_ssha512_password($password): string {
+        $salt = random_bytes(4);
+        return "{SSHA512}" . base64_encode(pack("H*", hash('sha512', $password . $salt)) . $salt);
+    }
+    
+    static function check_ssha512_password($password, $hash): bool {
+        $salt = substr(base64_decode(substr($hash, 9)), 64);   //salt of given hash (remove {SSHA512}, decode it, and only the bits after 512/8=64 bits)
+        $hash2 = "{SSHA512}".base64_encode(hash('sha512', $password.$salt, true).$salt);
+        return ($hash === $hash2);
+    }
+
+    # Create SHA password
+    static function make_sha_password($password): string {
+        return "{SHA}" . base64_encode(pack("H*", sha1($password)));
+    }
+    
+    static function check_sha_password($password, $hash): bool {
+        return ($hash === make_sha_password($password));
+    }
+
+    # Create SHA256 password
+    static function make_sha256_password($password): string {
+        return "{SHA256}" . base64_encode(pack("H*", hash('sha256', $password)));
+    }
+    
+    static function check_sha256_password($password, $hash): bool {
+        return ($hash === make_sha256_password($password));
+    }
+
+    # Create SHA384 password
+    static function make_sha384_password($password): string {
+        return "{SHA384}" . base64_encode(pack("H*", hash('sha384', $password)));
+    }
+    
+    static function check_sha384_password($password, $hash): bool {
+        return ($hash === make_sha384_password($password));
+    }
+
+    # Create SHA512 password
+    static function make_sha512_password($password): string {
+        return "{SHA512}" . base64_encode(pack("H*", hash('sha512', $password)));
+    }
+    
+    static function check_sha512_password($password, $hash): bool {
+        return ($hash === make_sha512_password($password));
+    }
+
+    # Create SMD5 password
+    static function make_smd5_password($password): string {
+        $salt = random_bytes(4);
+        return "{SMD5}" . base64_encode(pack("H*", md5($password . $salt)) . $salt);
+    }
+    
+    static function check_smd5_password($password, $hash): bool {
+        $salt = substr(base64_decode(substr($hash, 6)), 16);
+        $hash2 = "{SMD5}" . base64_encode(pack("H*", md5($password . $salt)) . $salt);
+        return ($hash === $hash2);
+    }
+
+    # Create MD5 password
+    static function make_md5_password($password): string {
+        return "{MD5}" . base64_encode(pack("H*", md5($password)));
+    }
+    
+    static function check_md5_password($password, $hash): bool {
+        return ($hash === make_md5_password($password));
+    }
+
+    # Create CRYPT password
+    static function make_crypt_password($password, $hash_options): string {
+
+        $salt_length = 2;
+        if ( isset($hash_options['crypt_salt_length']) ) {
+            $salt_length = $hash_options['crypt_salt_length'];
+        }
+
+        // Generate salt
+        $possible = '0123456789'.
+                    'abcdefghijklmnopqrstuvwxyz'.
+                    'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+                    './';
+        $salt = "";
+
+        while( strlen( $salt ) < $salt_length ) {
+            $salt .= substr( $possible, random_int( 0, strlen( $possible ) - 1 ), 1 );
+        }
+
+        if ( isset($hash_options['crypt_salt_prefix']) ) {
+            $salt = $hash_options['crypt_salt_prefix'] . $salt;
+        }
+
+        return '{CRYPT}' . crypt( $password,  $salt);
+    }
+    
+    static function check_crypt_password($password, $hash): bool {
+        return password_verify($password, substr($hash, 7));
+    }
+
+    # Create ARGON2 password
+    static function make_argon2_password($password, $hash_options): string {
+        if (!isset($hash_options['memory_cost'])) { $hash_options['memory_cost'] = 4096; } 
+        if (!isset($hash_options['time_cost'])) { $hash_options['time_cost'] = 3; } 
+        if (!isset($hash_options['threads'])) { $hash_options['threads'] = 1; }
+
+        return '{ARGON2}' . password_hash($password,PASSWORD_ARGON2I,$hash_options);
+    }
+    
+    static function check_argon2_password($password, $hash): bool {
+        return password_verify($password, substr($hash, 8));
+    }
+
+    # Create MD4 password (Microsoft NT password format)
+    static function make_md4_password($password): string {
+        if (function_exists('hash')) {
+            return strtoupper( hash( "md4", iconv( "UTF-8", "UTF-16LE", $password ) ) );
+        } else {
+            return strtoupper( bin2hex( mhash( MHASH_MD4, iconv( "UTF-8", "UTF-16LE", $password ) ) ) );
+        }
+    }
+    
+    static function check_md4_password($password, $hash): bool {
+        return ($hash === make_md4_password($password));
+    }
+
+    /**
+     * Generate a hash with the given algorithm and options.
+     * @param string $password the password to hash
+     * @param string $hash the algorithm to be used
+     * @param array $hash_options additional options to be used by the hashing algorithm
+     * @return string
+     */
+    static function make_password($password, $hash, $hash_options): string {
+        switch ($hash) {
+            case "clear":
+                return $password;
+            case "SSHA":
+                return make_ssha_password($password);
+            case "SSHA256":
+                return make_ssha256_password($password);
+            case "SSHA384":
+                return make_ssha384_password($password);
+            case "SSHA512":
+                return make_ssha512_password($password);
+            case "SHA":
+                return make_sha_password($password);
+            case "SHA256":
+                return make_sha256_password($password);
+            case "SHA384":
+                return make_sha384_password($password);
+            case "SHA512":
+                return make_sha512_password($password);
+            case "SMD5":
+                return make_smd5_password($password);
+            case "MD5":
+                return make_md5_password($password);
+            case "CRYPT":
+                return make_crypt_password($password, $hash_options);
+            case "ARGON2":
+                return make_argon2_password($password, $hash_options);
+            case "NTLM":
+                return make_md4_password($password);
+            default:
+                return $password;
+        }
+    }
+    /**
+     * @function check_password(string $password, string $hash, string $algo)
+     * Check if a password matches to a given hash.
+     * @param string $password (new) Password to match against the hash
+     * @param string $hash the stored hash the password has to match
+     * @param string $algo the hashing algorithm
+     * @return bool true: password and hash do match
+     */
+    static function check_password($password, $hash, $algo): bool {
+        switch ($algo) {
+            case "clear":
+                return $password == $hash;
+            case "SSHA":
+                return check_ssha_password($password, $hash);
+            case "SSHA256":
+                return check_ssha256_password($password, $hash);
+            case "SSHA384":
+                return check_ssha384_password($password, $hash);
+            case "SSHA512":
+                return check_ssha512_password($password, $hash);
+            case "SHA":
+                return check_sha_password($password, $hash);
+            case "SHA256":
+                return check_sha256_password($password, $hash);
+            case "SHA384":
+                return check_sha384_password($password, $hash);
+            case "SHA512":
+                return check_sha512_password($password, $hash);
+            case "SMD5":
+                return check_smd5_password($password, $hash);
+            case "MD5":
+                return check_md5_password($password, $hash);
+            case "CRYPT":
+                return check_crypt_password($password, $hash);
+            case "ARGON2":
+                return check_argon2_password($password, $hash);
+            case "NTLM":
+                return check_md4_password($password, $hash);
+            default:
+                return $password == $hash;
+        }
+    }
+
+    # Create AD password (Microsoft Active Directory password format)
+    static function make_ad_password($password): string {
+        $password = "\"" . $password . "\"";
+        $adpassword = mb_convert_encoding($password, "UTF-16LE", "UTF-8");
+        return $adpassword;
+    }
+
+    /**
+     * @function check_hash_type(\LDAP\Connection|array $ldap, array|string $dn, string $pwdattribute)
+     * Read the password attribute and return the algorithm used to hash the password.
+     * @param string $pwdattribute the attribute where the hash is stored
+     * @return string algorithm used with the hash
+     */
+    static function get_hash_type($pwdattribute): string {
+        $matches = array();
+        if (isset($userpassword) && preg_match('/^\{(\w+)\}/', $userpassword[0], $matches)) {
+            return strtoupper($matches[1]);
+        }
+    }
+    
+    static function set_samba_data($userdata, $samba_options, $password): void {
+        $time = time();
+        $userdata["sambaNTPassword"] = make_md4_password($password);
+        $userdata["sambaPwdLastSet"] = $time;
+        if ( isset($samba_options['min_age']) && $samba_options['min_age'] > 0 ) {
+             $userdata["sambaPwdCanChange"] = $time + ( $samba_options['min_age'] * 86400 );
+        }
+        if ( isset($samba_options['max_age']) && $samba_options['max_age'] > 0 ) {
+             $userdata["sambaPwdMustChange"] = $time + ( $samba_options['max_age'] * 86400 );
+        }
+        if ( isset($samba_options['expire_days']) && $samba_options['expire_days'] > 0 ) {
+             $userdata["sambaKickoffTime"] = $time + ( $samba_options['expire_days'] * 86400 );
+        }
+    }
+    
+    static function set_ad_data($userdata, $ad_options, $password): void {
+        $userdata["unicodePwd"] = $password;
+        if ( $ad_options['force_unlock'] ) {
+            $userdata["lockoutTime"] = 0;
+        }
+        if ( $ad_options['force_pwd_change'] ) {
+            $userdata["pwdLastSet"] = 0;
+        }
+    }
+    
+    static function set_shadow_data($userdata, $shadow_options): void {
+        $time = time();
+        if ( $shadow_options['update_shadowLastChange'] ) {
+            $userdata["shadowLastChange"] = floor($time / 86400);
+        }
+
+        if ( $shadow_options['update_shadowExpire'] ) {
+            if ( $shadow_options['shadow_expire_days'] > 0) {
+              $userdata["shadowExpire"] = floor(($time / 86400) + $shadow_options['shadow_expire_days']);
+            } else {
+              $userdata["shadowExpire"] = $shadow_options['shadow_expire_days'];
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The code in this PR mainly comes from SSP, and is a bit factorized by me. 

I will tell you why the functions should be included here:

|Function|can be used by SSP|can be used by SD|Why?|
|---|---|---|---|
|`make_xxx_password`|X|X|needed for `make_password()`|
|`check_xxx_password`|X|X|needed for `check_password()`|
|`make_password`|X|X|In SD, changing the Password is only possible using PPolicy. If you dont want this, you have to create the hash in SD|
|`check_password()`|X|X|can be to check if the current set password is the same as the new one (and is also part of a PR I have..)|
|`make_ad_password`|X|X|SD does not support AD yet, this could be a starting point|
|`get_hash_type`|X|X|same mechanism as in SSP: if you want to use `$hash = "auto"`|
|`set_samba_data`|X|X|SD does not provide support for Samba yet|
|`set_ad_data`|X|X|SD does not support AD yet, this could be a starting point|
|`set_shadow_data`|X|X|SD does not support shadow yet|
|`get_hashed_password`|X|X|if you want to use `$hash = "auto"`, you first have to get the current hash|
|`change_ad_password_as_user`|X| |if `change_password_using_ppolicy()` and `change_password()` make they way to here, it should also be included|
|`change_password_with_exop`|X| |    |
|`change_password_using_ppolicy`|X|X|currently, only password modifaction with enabled ppolicy is supported by SD. So, beeing able to parse ppolicy errors would be nice!|
|`change_password`|X|X|The default password modification|

A starting point for following: 

- https://github.com/ltb-project/service-desk/issues/50
- https://github.com/ltb-project/service-desk/issues/52
- https://github.com/ltb-project/service-desk/issues/57

This is a proposal, maybe a starting point for a discussion what should and what should not be included here. For example, SD and WP share a big amount of similarity in there smarty templates. Maybe this can also be included here? Where is the limit?