### PR TITLE
Function to match a DN against fliter, base and scope

### DIFF
--- a/src/Ltb/Directory.php
+++ b/src/Ltb/Directory.php
@@ -74,4 +74,9 @@ interface Directory
      * Get password policy configuration
      */
     public function getPwdPolicyConfiguration($ldap, $entry_dn, $default_ppolicy_dn) : Array;
+
+    /*
+     * Return special attribute name containing entry DN
+     */
+    public function getDnAttribute() : string;
 }

--- a/src/Ltb/Directory/ActiveDirectory.php
+++ b/src/Ltb/Directory/ActiveDirectory.php
@@ -318,4 +318,8 @@ class ActiveDirectory implements \Ltb\Directory
 
         return $ppolicyConfig;
     }
+
+    public function getDnAttribute() : string {
+        return "distinguishedName";
+    }
 }

--- a/src/Ltb/Directory/OpenLDAP.php
+++ b/src/Ltb/Directory/OpenLDAP.php
@@ -314,4 +314,7 @@ class OpenLDAP implements \Ltb\Directory
         return $ppolicyConfig;
     }
 
+    public function getDnAttribute() : string {
+        return "entryDn";
+    }
 }

--- a/src/Ltb/Ldap.php
+++ b/src/Ltb/Ldap.php
@@ -493,7 +493,8 @@ class Ldap {
     public function matchDn($dn, $dnAttribute, $filter, $base, $scope): bool {
 
         # Build filter
-        $search_filter = '(&' . $filter . '(' . $dnAttribute . '=' . $dn .'))';
+        $dn_escape = ldap_escape($dn, "", LDAP_ESCAPE_FILTER);
+        $search_filter = '(&' . $filter . '(' . $dnAttribute . '=' . $dn_escape .'))';
 
         # Search with scope
         $search = $this->search_with_scope($scope, $base, $search_filter, ['1.1']);

--- a/src/Ltb/Ldap.php
+++ b/src/Ltb/Ldap.php
@@ -481,5 +481,27 @@ class Ldap {
 
     }
 
+    /**
+     * test if a DN matches filter, base and scope
+     * @param string $dn: entry DN
+     * @param string $dnAttribute: attribute name containing the DN
+     * @param string $filter
+     * @param string $base
+     * @param string $scope
+     * @return bool: true if DN matches filter, base and scope
+     */
+    public function matchDn($dn, $dnAttribute, $filter, $base, $scope): bool {
+
+        # Build filter
+        $search_filter = '(&' . $filter . '(' . $dnAttribute . '=' . $dn .'))';
+
+        # Search with scope
+        $search = $this->search_with_scope($scope, $base, $search_filter, ['1.1']);
+
+        $count = \Ltb\PhpLDAP::ldap_count_entries($this->ldap, $search);
+
+        if ( $count == 1) { return true; }
+        return false;
+    }
 }
 ?>

--- a/tests/Ltb/LdapTest.php
+++ b/tests/Ltb/LdapTest.php
@@ -1214,6 +1214,28 @@ final class LdapTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
     }
 
+    public function test_matchDn(): void
+    {
+
+        $phpLDAPMock = Mockery::mock('overload:Ltb\PhpLDAP');
+
+        $phpLDAPMock->shouldreceive('ldap_search')
+                    ->with("ldap_connection", "ou=people,dc=my-domain,dc=com", "(&(objectClass=inetOrgPerson)(entryDn=uid=test,ou=people,dc=my-domain,dc=com))", [1.1])
+                    ->andReturn(array("ldap_search_result"));
+
+        $phpLDAPMock->shouldreceive('ldap_count_entries')
+                    ->with("ldap_connection", array("ldap_search_result"))
+                    ->andReturn(1);
+
+        $ldapInstance = new \Ltb\Ldap( null, null, null, null, null, null, null, null );
+        $ldapInstance->ldap = "ldap_connection";
+
+        $result_match = $ldapInstance->matchDn("uid=test,ou=people,dc=my-domain,dc=com", "entryDn", "(objectClass=inetOrgPerson)", "ou=people,dc=my-domain,dc=com", "sub");
+
+        $this->assertTrue($result_match, "DN match");
+
+    }
+
     public function setUp(): void
     {
         // Turn on error reporting


### PR DESCRIPTION
This function allows to verify if an entry matches configured filter, base and scope.

This will be used to be sure operations are not done on an entry that is outside the configured settings.